### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ httpx==0.26.0
 ray[serve]==2.23.0
 git+https://github.com/toilaluan/controlnet_aux.git
 timm==1.0.3
-numpy==1.26.4
+numpy==1.26
 pandas
 typesense
 clean-text[gpl]


### PR DESCRIPTION
I was downgraded to numpy==1.26, as numpy==1.26.4 was causing issues with setting up an LLM miner. Tegridy, with the help of the team, assisted me in reaching this conclusion!