### PR TITLE
Add new synthetic mechanism

### DIFF
--- a/neurons/validator/validator.py
+++ b/neurons/validator/validator.py
@@ -761,19 +761,21 @@ class Validator(BaseValidatorNeuron):
                     if len(self.rewarded_synapses[model_name]) > 0:
                         rand_val = random.random()
                         if rand_val < 0.8:  # 80% chance to use existing synapse
-                            synapses[i] = random.choice(self.rewarded_synapses[model_name]).model_copy()
+                            synapses[i] = random.choice(self.rewarded_synapses[model_name]).model_copy(deep=True)
                         elif rand_val < 0.9:  # 10% chance to use existing synapse with new seed
-                            synapse = random.choice(self.rewarded_synapses[model_name]).model_copy()
+                            synapse = random.choice(self.rewarded_synapses[model_name]).model_copy(deep=True)
                             synapse.seed = random.randint(0, 1e9)
                             synapses[i] = synapse
                         # else: 10% chance to use new synapse (already created)
-                    self.rewarded_synapses[model_name].append(synapses[i])
+                    self.rewarded_synapses[model_name].append(synapses[i].model_copy(deep=True))
                 else:
                     # select old not rewarded synapse with probability
-                    if random.random() < 0.3 and len(self.not_rewarded_synapses[model_name]) > 0:
-                        synapses[i] = random.choice(self.not_rewarded_synapses[model_name]).model_copy()
+                    if random.random() < 0.1 and len(self.not_rewarded_synapses[model_name]) > 0:
+                        synapses[i] = random.choice(self.not_rewarded_synapses[model_name]).model_copy(deep=True)
                     else:
-                        self.not_rewarded_synapses[model_name].append(synapses[i])
+                        # limit the number of not rewarded synapses to be less or equal the number of rewarded synapses
+                        if len(self.not_rewarded_synapses[model_name]) < len(self.rewarded_synapses[model_name]):
+                            self.not_rewarded_synapses[model_name].append(synapses[i].model_copy(deep=True))
 
         if self.nicheimage_catalogue[model_name]["reward_type"] == "open_category":
             # Reward same test for uids in same open category

--- a/neurons/validator/validator.py
+++ b/neurons/validator/validator.py
@@ -73,6 +73,7 @@ class QueryQueue:
                 else:
                     synthentic_model_queue.put(QueryItem(uid=uid, should_reward=True))
                     self.synthentic_rewarded.append(uid)
+
             for _ in range(int(proxy_rate_limit)):
                 proxy_model_queue.put(QueryItem(uid=uid))
         # Shuffle the queue

--- a/neurons/validator/validator.py
+++ b/neurons/validator/validator.py
@@ -753,29 +753,30 @@ class Validator(BaseValidatorNeuron):
                 synapses = ig_subnet.validator.get_challenge(
                     challenge_url, synapses, backup_func
                 )
-                
+
         if self.nicheimage_catalogue[model_name]["reward_type"] != "open_category":
             for i, batch in enumerate(batched_uids_should_rewards):
                 if any([should_reward for _, should_reward in batch]):
                     # select old rewarded synapse with probability
-                    if len(self.rewarded_synapses[model_name]) > 0:
-                        rand_val = random.random()
+                    rand_val = random.random()
+                    if len(self.rewarded_synapses[model_name]) > 0 and rand_val < 0.9:
                         if rand_val < 0.8:  # 80% chance to use existing synapse
                             synapses[i] = random.choice(self.rewarded_synapses[model_name]).model_copy(deep=True)
-                        elif rand_val < 0.9:  # 10% chance to use existing synapse with new seed
+                        else: # 10% chance to use existing synapse with new seed
                             synapse = random.choice(self.rewarded_synapses[model_name]).model_copy(deep=True)
                             synapse.seed = random.randint(0, 1e9)
                             synapses[i] = synapse
+                    else:
                         # else: 10% chance to use new synapse (already created)
-                    self.rewarded_synapses[model_name].append(synapses[i].model_copy(deep=True))
+                        self.rewarded_synapses[model_name].append(synapses[i].model_copy(deep=True))
+
                 else:
                     # select old not rewarded synapse with probability
                     if random.random() < 0.1 and len(self.not_rewarded_synapses[model_name]) > 0:
                         synapses[i] = random.choice(self.not_rewarded_synapses[model_name]).model_copy(deep=True)
-                    else:
+                    elif len(self.not_rewarded_synapses[model_name]) < len(self.rewarded_synapses[model_name]):
                         # limit the number of not rewarded synapses to be less or equal the number of rewarded synapses
-                        if len(self.not_rewarded_synapses[model_name]) < len(self.rewarded_synapses[model_name]):
-                            self.not_rewarded_synapses[model_name].append(synapses[i].model_copy(deep=True))
+                        self.not_rewarded_synapses[model_name].append(synapses[i].model_copy(deep=True))
 
         if self.nicheimage_catalogue[model_name]["reward_type"] == "open_category":
             # Reward same test for uids in same open category

--- a/neurons/validator/validator.py
+++ b/neurons/validator/validator.py
@@ -31,9 +31,9 @@ MODEL_CONFIGS = yaml.load(
 
 
 class QueryItem:
-    def __init__(self, uid: int):
+    def __init__(self, uid: int, should_reward: bool = False):
         self.uid = uid
-
+        self.should_reward = should_reward # currently only used for synthetic query
 
 class QueryQueue:
     def __init__(self, model_names: list[str], time_per_loop: int = 600):
@@ -66,8 +66,13 @@ class QueryQueue:
             synthetic_rate_limit, proxy_rate_limit = self.get_rate_limit_by_type(
                 info["rate_limit"]
             )
+
             for _ in range(int(synthetic_rate_limit)):
-                synthentic_model_queue.put(QueryItem(uid=uid))
+                if uid in self.synthentic_rewarded:
+                    synthentic_model_queue.put(QueryItem(uid=uid, should_reward=False))
+                else:
+                    synthentic_model_queue.put(QueryItem(uid=uid, should_reward=True))
+                    self.synthentic_rewarded.append(uid)
             for _ in range(int(proxy_rate_limit)):
                 proxy_model_queue.put(QueryItem(uid=uid))
         # Shuffle the queue
@@ -102,11 +107,7 @@ class QueryQueue:
                     more_data = True
                     query_item = q.get()
                     uids_to_query.append(query_item.uid)
-                    if query_item.uid in self.synthentic_rewarded:
-                        should_rewards.append(False)
-                    else:
-                        should_rewards.append(True)
-                        self.synthentic_rewarded.append(query_item.uid)
+                    should_rewards.append(query_item.should_reward)
 
                 yield model_name, uids_to_query, should_rewards, time_to_sleep
 
@@ -508,12 +509,14 @@ class Validator(BaseValidatorNeuron):
 
         bt.logging.info("Updating available models & uids")
         async_batch_size = self.config.async_batch_size
-        loop_base_time = self.config.loop_base_time  # default is 600 seconds
+        loop_base_time = self.config.loop_base_time
         self.open_category_reward_synapses = self.init_reward_open_category_synapses()
         threads = []
         loop_start = time.time()
         self.miner_manager.update_miners_identity()
         self.query_queue.update_queue(self.miner_manager.all_uids_info)
+        self.rewarded_synapses = {model_name: [] for model_name in self.nicheimage_catalogue.keys()}
+        self.not_rewarded_synapses = {model_name: [] for model_name in self.nicheimage_catalogue.keys()}
 
         for (
             model_name,
@@ -633,6 +636,7 @@ class Validator(BaseValidatorNeuron):
                     axons.append(self.miner_manager.layer_one_axons[uid])
                 else:
                     axons.append(self.metagraph.axons[uid])
+
             responses = dendrite.query(
                 axons=axons,
                 synapse=synapse,
@@ -717,7 +721,8 @@ class Validator(BaseValidatorNeuron):
                 if info["model_name"] == model_name
             ]
         )
-        batch_size = min(4, 1 + model_miner_count // 4)
+        # batch_size = min(4, 1 + model_miner_count // 4)
+        batch_size = 1
 
         random.shuffle(uids_should_rewards)
         batched_uids_should_rewards = [
@@ -748,6 +753,28 @@ class Validator(BaseValidatorNeuron):
                 synapses = ig_subnet.validator.get_challenge(
                     challenge_url, synapses, backup_func
                 )
+                
+        if self.nicheimage_catalogue[model_name]["reward_type"] != "open_category":
+            for i, batch in enumerate(batched_uids_should_rewards):
+                if any([should_reward for _, should_reward in batch]):
+                    # select old rewarded synapse with probability
+                    if len(self.rewarded_synapses[model_name]) > 0:
+                        rand_val = random.random()
+                        if rand_val < 0.8:  # 80% chance to use existing synapse
+                            synapses[i] = random.choice(self.rewarded_synapses[model_name]).model_copy()
+                        elif rand_val < 0.9:  # 10% chance to use existing synapse with new seed
+                            synapse = random.choice(self.rewarded_synapses[model_name]).model_copy()
+                            synapse.seed = random.randint(0, 1e9)
+                            synapses[i] = synapse
+                        # else: 10% chance to use new synapse (already created)
+                    self.rewarded_synapses[model_name].append(synapses[i])
+                else:
+                    # select old not rewarded synapse with probability
+                    if random.random() < 0.3 and len(self.not_rewarded_synapses[model_name]) > 0:
+                        synapses[i] = random.choice(self.not_rewarded_synapses[model_name]).model_copy()
+                    else:
+                        self.not_rewarded_synapses[model_name].append(synapses[i])
+
         if self.nicheimage_catalogue[model_name]["reward_type"] == "open_category":
             # Reward same test for uids in same open category
             for i, batch in enumerate(batched_uids_should_rewards):

--- a/services/rewarding/app.py
+++ b/services/rewarding/app.py
@@ -145,7 +145,7 @@ class FixedCategoryRewardApp(BaseRewardApp):
         super().__init__(args)
         self.rewarder = CosineSimilarityReward()
         self.model_handle = model_handle
-        self.cache = dc.Cache("fixed_category_cache")
+        self.cache = dc.Cache("fixed_category_cache", size_limit=5*1024*1024*1024) # 5GB
         self.ttl = 600
 
     async def __call__(self, reward_request: RewardRequest):

--- a/services/rewarding/app.py
+++ b/services/rewarding/app.py
@@ -138,17 +138,24 @@ class BaseRewardApp:
     async def __call__(self, reward_request: RewardRequest):
         raise NotImplementedError("This method should be implemented by subclasses")
 
+import diskcache as dc
 
 class FixedCategoryRewardApp(BaseRewardApp):
     def __init__(self, model_handle: DeploymentHandle, args):
         super().__init__(args)
         self.rewarder = CosineSimilarityReward()
         self.model_handle = model_handle
+        self.cache = dc.Cache("fixed_category_cache")
+        self.ttl = 600
 
     async def __call__(self, reward_request: RewardRequest):
         base_data = reward_request.base_data
         miner_data = reward_request.miner_data
-        validator_image = await self.model_handle.generate.remote(prompt_data=base_data)
+        validator_image = self.cache.get(base_data)
+        if not validator_image:
+            validator_image = await self.model_handle.generate.remote(prompt_data=base_data)
+            self.cache.set(base_data, validator_image, expire=self.ttl)
+
         miner_images = [d.image for d in miner_data]
         rewards = self.rewarder.get_reward(
             validator_image, miner_images, base_data.pipeline_type

--- a/services/rewarding/requirements.txt
+++ b/services/rewarding/requirements.txt
@@ -12,3 +12,4 @@ transformers
 omegaconf
 gunicorn
 prometheus-fastapi-instrumentator==6.0.0
+diskcache==5.6.3


### PR DESCRIPTION
# Pull Request: Improve Synthetic Mechanism

## Summary
This pull request introduces enhancements to the synthetic mechanism to improve the integrity and fairness of the process. The updates include shuffling the query queue, incorporating random seeds for synapses, and probabilistically reusing old synapses to obscure reward patterns.

## Changes Introduced

### Old Mechanism
1. Query `should_reward` synapses at the beginning of each forward pass.
   - A miner could identify whether a synapse is the first send from each validator, allowing for exploitation by skipping later synapses.
2. Query synapse follow batches with one synapse per batch.
   - Miners with multiple accounts could share results, reducing fairness.

### New Mechanism
1. **Shuffle Query Queue:**
   - At the start of each forward pass, the query queue is shuffled to prevent miners from predicting the order of synapse queries.
2. **Random Seed for Synapses:**
   - Each synapse in a batch is assigned a random seed, making it difficult for miners to share results across accounts.
3. **Probabilistic Reuse of Synapses:**
   - Previously rewarded synapses are reused with a certain probability.
   - Previously not rewarded synapses are reused with a certain probability.
   - This obscures which synapses are `should_reward` synapses, further reducing exploitability.

## Implementation Details
The changes were implemented as follows:

### Shuffling Query Queue
- Added a shuffle function to reorder the query queue before each forward pass.
- Ensures that the order of synapse queries is unpredictable.

### Random Seed for Synapses
- Introduced a random seed generator for synapses.
- Each batch of synapses receives a unique random seed.
- Prevents miners from easily replicating or sharing results.

### Probabilistic Synapse Reuse
- Added logic to reuse old synapses with a tunable probability:
  - Reuse rewarded synapses with probability `p_rewarded`.
  - Reuse not rewarded synapses with probability `p_not_rewarded`.
- These probabilities are configurable for flexibility and experimentation.

## Benefits
1. Increased difficulty for miners to identify `should_reward` synapses.
2. Reduced potential for multi-account result sharing.
3. Enhanced overall fairness and security of the mechanism.
---
